### PR TITLE
Fix cellcounter failing tests

### DIFF
--- a/cellcounter/keyboardapi/tests.py
+++ b/cellcounter/keyboardapi/tests.py
@@ -41,6 +41,7 @@ class KeyboardFactory(factory.django.DjangoModelFactory):
 
 
 class CustomKeyboardTestCase(TestCase):
+    fixtures = ['cellcounter/main/fixtures/initial_data.json']
 
     def test_unicode(self):
         keyboard = KeyboardFactory.build(user__username='alpha', label='alpha')


### PR DESCRIPTION
Fixed missing fixtures declaration to fix tests. These tests are _not_ self contained, and ideally should be, but for the moment, we'll have passing tests again.
