### PR TITLE
Fix for cellcounter/cellcounter#220

### DIFF
--- a/cellcounter/cc_kapi/static/js/counter.js
+++ b/cellcounter/cc_kapi/static/js/counter.js
@@ -330,6 +330,10 @@ $(document).ready(function() {
                     for (i=0; i<cell_types[c_id].box.length; i++){
                         $(cell_types[c_id].box[i]).find(span_field).text(cell_types[c_id][c_type]);
                     }
+                    /* Re-initiate visualisation if key_history has been deleted completely */
+                    if (key_history.length === 0) {
+                        init_visualisation("#doughnut");
+                    }
                 } else {
                     /* Nothing to delete */
                     key_history = [];


### PR DESCRIPTION
Re-initiates visualisation if key_history has been deleted back to empty.
