### PR TITLE
Replaces old new_count view

### DIFF
--- a/cellcounter/main/views.py
+++ b/cellcounter/main/views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
-from django.views.generic import ListView
+from django.views.generic import ListView, TemplateView
 from PIL import Image
 
 from cellcounter.main.models import CellType, CellImage
@@ -27,15 +27,12 @@ class ListCellTypesView(JSONResponseMixin, ListView):
         return new_context
 
 
-def new_count(request):
-        cellcount_form_list = []
-        for celltype in CellType.objects.all():
-            cellcount_form_list.append(celltype)
+class NewCountTemplateView(TemplateView):
+    template_name = 'main/count.html'
 
-        return render_to_response('main/count.html',
-                                  {'cellcountformslist': cellcount_form_list,
-                                   'logged_in': request.user.is_authenticated()},
-                                  context_instance=RequestContext(request))
+    def get_context_data(self, **kwargs):
+        context = super(NewCountTemplateView, self).get_context_data(**kwargs)
+        context['logged_in'] = self.request.user.is_authenticated()
 
 
 def images_by_cell_type(request, cell_type):

--- a/cellcounter/urls.py
+++ b/cellcounter/urls.py
@@ -6,7 +6,7 @@ from django.views.generic import TemplateView
 from django.contrib import admin
 from django.contrib.auth.views import login, logout
 
-from cellcounter.main.views import new_count, images_by_cell_type, ListCellTypesView, similar_images, thumbnail, page
+from cellcounter.main.views import NewCountTemplateView, images_by_cell_type, ListCellTypesView, similar_images, thumbnail, page
 
 from cellcounter.logs.views import index, host_access, page_access, referrer_access, date_access
 
@@ -14,7 +14,7 @@ admin.autodiscover()
 
 urlpatterns = patterns('',
 
-    url(r'^$', new_count, name="new_count"),
+    url(r'^$', NewCountTemplateView.as_view(), name="new_count"),
 
     url(r'^discover/$', TemplateView.as_view(template_name="main/discover.html"), name="discover"),
     url(r'^about/$', TemplateView.as_view(template_name="main/about.html"), name="about"),


### PR DESCRIPTION
Old new_count view hits the database to load a list of cellcount_forms which no longer are used. Replaced with a clean implementation via TemplateView.
