### PR TITLE
Move loading visualise.js and counter.js to the count page only

### DIFF
--- a/cellcounter/main/templates/main/base.html
+++ b/cellcounter/main/templates/main/base.html
@@ -106,8 +106,6 @@
 <script src="{% static "js/bootstrap.min.js" %}"></script>
 <script src="{% static "js/bootstrap-editable.min.js" %}"></script>
 <script src="{% static "js/images.js" %}"></script>
-<script src="{% static "js/visualise.js" %}"></script>
-<script src="{% static "js/counter.js" %}"></script>
 
 <script type="text/javascript" src="{% static "js/swfobject.js" %}"></script>
 <script type="text/javascript" src="{% static "js/downloadify.min.js" %}"></script>

--- a/cellcounter/main/templates/main/count.html
+++ b/cellcounter/main/templates/main/count.html
@@ -57,6 +57,8 @@ var notloggedin=true;
 {% endblock %}
 
 {% block additional_scripts %}
+<script src="{% static "js/visualise.js" %}"></script>
+<script src="{% static "js/counter.js" %}"></script>
 <script>
     $(function() {
         open_keyboard();


### PR DESCRIPTION
This speeds up page loading as when `counter.js` is loaded it hits other URLs - `/api/keyboards` and `/api/cell_types`. These are only needed on pages where the counter is, not every page. Moving these scripts saves 2 extra HTTP requests per non-counting page.
