### PR TITLE
cellcounter/cellcounter#192

### DIFF
--- a/cellcounter/main/static/css/keyboard.css
+++ b/cellcounter/main/static/css/keyboard.css
@@ -257,7 +257,7 @@ div#celllist li.selected div.element {
 #edit_button {
     position: absolute;
     margin-top: 8px;
-    right: 8px;
+    right: 20px;
 }
 
 #reset_button {


### PR DESCRIPTION
A fix for cellcounter/cellcounter#192. This moves the reset_count button to the right margin of the keyboard, and sets the right-indent of the edit_keyboard button to the same.
