### PR TITLE
Updated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 Django==1.6.5
-Pillow==2.4.0
+Pillow==2.5.1
 South==1.0
 dj-database-url==0.3.0
-django-colorful==1.0.0
+django-colorful==1.0.1
 django-braces==1.4.0
 djangorestframework==2.3.14
 django-pylibmc==0.5.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,5 @@ WebTest==2.0.15
 beautifulsoup4==4.3.2
 django-webtest==1.7.7
 factory-boy==2.4.1
-six==1.7.2
+six==1.7.3
 waitress==0.8.9


### PR DESCRIPTION
Updated:
- PIllow to 2.5.1
- Django-Colorful to 1.0.1
- Six to 1.7.3
