### PR TITLE
Take ALLOWED_HOSTS setting from environment

### DIFF
--- a/cellcounter/settings.py
+++ b/cellcounter/settings.py
@@ -118,7 +118,7 @@ SECURE_REQUIRED_PATHS = (
     # '/accounts/',
 )
 
-ALLOWED_HOSTS = ['.cellcountr.com']
+ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',')
 
 ROOT_URLCONF = 'cellcounter.urls'
 


### PR DESCRIPTION
Cellcountr should pull its `ALLOWED_HOSTS` setting from the environment.