### PR TITLE
Temporarily use github checkout for django-compressor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ dj-database-url==0.4.1
 django-colorful==1.1.0
 django-braces==1.8.1
 djangorestframework==3.3.3
-django-compressor==2.0
 django-pylibmc==0.6.1
 django-ratelimit==1.0.0
 pylibmc==1.5.1
@@ -12,3 +11,4 @@ pytz==2016.3
 psycopg2==2.6.1
 uWSGI==2.0.12
 wsgiref==0.1.2
+-e git+https://github.com/django-compressor/django-compressor.git@51ec27f54f9524c727f01e23abbff3183b598b7e#egg=django_compressor


### PR DESCRIPTION
No current django-compressor release supporting Django 1.10, should be released this week.