### PR TITLE
Fixes cellcounter/cellcounter#439

### DIFF
--- a/cellcounter/cc_kapi/static/js/counter.js
+++ b/cellcounter/cc_kapi/static/js/counter.js
@@ -892,11 +892,17 @@ function clear_keyboard() {
     if ('id' in keyboard_map) {
         var id = keyboard_map.id;
     }
+    if ('user' in keyboard_map) {
+        var user = keyboard_map.user;
+    }
     var date = new Date(Date.now()).toISOString();
     keyboard_map = {"label": "Default", "is_primary": true, "created": date,
                     "last_modified": date, "mappings": []};
     if (typeof id !== 'undefined') {
         keyboard_map.id = id;
+    }
+    if (typeof user !== 'undefined') {
+        keyboard_map.user = user;
     }
     update_keyboard();
 }


### PR DESCRIPTION
The source of this bug appears to be the fact that the 'clear key map' function strips out the user from the keyboard_map. On saving, this leads to a 400 error, as the 'user' field has not been provided.

This fix ensures 'user' is preserved across keymap clearances.