### PR TITLE
Update dependencies, correct deprecated behaviour

### DIFF
--- a/cellcounter/main/serializers.py
+++ b/cellcounter/main/serializers.py
@@ -6,3 +6,4 @@ from .models import CellType
 class CellTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = CellType
+        fields = '__all__'

--- a/cellcounter/statistics/serializers.py
+++ b/cellcounter/statistics/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework.serializers import ModelSerializer
+
 from .models import CountInstance
 
 
@@ -11,3 +12,4 @@ class CountInstanceCreateSerializer(ModelSerializer):
 class CountInstanceModelSerializer(ModelSerializer):
     class Meta:
         model = CountInstance
+        fields = '__all__'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-Django==1.10.2
-Pillow==3.4.1
+Django==1.10.3
+Pillow==3.4.2
 dj-database-url==0.4.1
 django-colorful==1.2
-django-braces==1.9.0
-djangorestframework==3.4.7
+django-compressor==2.1
+django-braces==1.10.0
+djangorestframework==3.5.3
 djangorestframework-xml==1.3.0
 django-pylibmc==0.6.1
 django-ratelimit==1.0.1
@@ -12,4 +13,3 @@ pytz==2016.7
 psycopg2==2.6.2
 uWSGI==2.0.14
 wsgiref==0.1.2
--e git+https://github.com/django-compressor/django-compressor.git@51ec27f54f9524c727f01e23abbff3183b598b7e#egg=django_compressor


### PR DESCRIPTION
Updates:
* Django 1.10.3
* Pillow 3.4.2
* Django compressor 2.1  (no longer requiring a separate Git checkout)
* Django braces 1.10.0
* Django rest framework 3.5.3

In Django Rest Framework 3.5.3 ModelSerializers now require an explicit 'fields' attribute. Updates two instances where this was not explicit.